### PR TITLE
Check if monitor object has correct index property

### DIFF
--- a/Rounded_Corners@lennart-k/extension.js
+++ b/Rounded_Corners@lennart-k/extension.js
@@ -41,13 +41,17 @@ Ext.prototype.initCorners = function (radius) {
     this.destroyCorners()
 
     let monitors = Main.layoutManager.monitors;
-
+    
     for (let m in Main.layoutManager.monitors) {
         let monitor = monitors[m];
 
+        if(typeof monitor.index === 'undefined') {
+            continue;
+        }
+
         for (let c in corner_types) {
             let corner = corner_types[c];
-
+            
             corners[monitor.index + corner] = new St.Bin({
                 style_class: 'corner' + corner,
                 reactive: false,

--- a/Rounded_Corners@lennart-k/extension.js
+++ b/Rounded_Corners@lennart-k/extension.js
@@ -45,7 +45,7 @@ Ext.prototype.initCorners = function (radius) {
     for (let m in Main.layoutManager.monitors) {
         let monitor = monitors[m];
 
-        if(typeof monitor.index === 'undefined') {
+        if(monitor.index == undefined) {
             continue;
         }
 


### PR DESCRIPTION
Fixes #1 

In multi-monitor setup, `monitor.index` can be undefined and it causes an empty square to be created. A simple `if` check solves it.