### PR TITLE
Add scaled monitor support

### DIFF
--- a/Rounded_Corners@lennart-k/extension.js
+++ b/Rounded_Corners@lennart-k/extension.js
@@ -64,14 +64,14 @@ Ext.prototype.initCorners = function (radius) {
         corners[monitor.index + 'tl'].x = monitor.x;
         corners[monitor.index + 'tl'].y = monitor.y;
 
-        corners[monitor.index + 'tr'].x = monitor.x + monitor.width - radius;
+        corners[monitor.index + 'tr'].x = monitor.x + monitor.width - monitor.geometry_scale * radius;
         corners[monitor.index + 'tr'].y = monitor.y;
 
         corners[monitor.index + 'bl'].x = monitor.x;
-        corners[monitor.index + 'bl'].y = monitor.y + monitor.height - radius;
+        corners[monitor.index + 'bl'].y = monitor.y + monitor.height - monitor.geometry_scale * radius;
 
-        corners[monitor.index + 'br'].x = monitor.x + monitor.width - radius;
-        corners[monitor.index + 'br'].y = monitor.y + monitor.height - radius;
+        corners[monitor.index + 'br'].x = monitor.x + monitor.width - monitor.geometry_scale * radius;
+        corners[monitor.index + 'br'].y = monitor.y + monitor.height - monitor.geometry_scale * radius;
     }
 
     for (let c in corners) {


### PR DESCRIPTION
Hey, I noticed this only worked for the top left corner on my 4k display with display scaling set to 200%. After some fiddling I found this fix that should work for all display scaling settings.

I tested it on 100% and 200% scaling.