### PR TITLE
Added support for Gnome-shell-40.0

### DIFF
--- a/Rounded_Corners@lennart-k/metadata.json
+++ b/Rounded_Corners@lennart-k/metadata.json
@@ -2,6 +2,6 @@
     "name": "Rounded Corners",
     "description": "Creates rounded corners for every monitor",
     "uuid": "Rounded_Corners@lennart-k",
-    "shell-version": ["3.36", "3.38"],
+    "shell-version": ["3.36", "3.38","40.0"],
     "url": "https://github.com/lennart-k/gnome-rounded-corners"
 }


### PR DESCRIPTION
Added 40.0 in shell-version in metadata.json
Configure doesn't work yet!
You could use dconf-editor thou!