### PR TITLE
GNOME 41 Support

### DIFF
--- a/Rounded_Corners@lennart-k/metadata.json
+++ b/Rounded_Corners@lennart-k/metadata.json
@@ -2,6 +2,6 @@
     "name": "Rounded Corners",
     "description": "Creates rounded corners for every monitor",
     "uuid": "Rounded_Corners@lennart-k",
-    "shell-version": ["3.36", "3.38", "40"],
+    "shell-version": ["3.36", "3.38", "40", "41"],
     "url": "https://github.com/lennart-k/gnome-rounded-corners"
 }


### PR DESCRIPTION
The extension and its settings window appear to work without issue on GNOME 41, so I've just updated the metadata.json file to reflect that.